### PR TITLE
Added boolean indicator to AST.attribute type 

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -32,10 +32,10 @@ and character_range = char list
 and attribute =
   | NoAttribute
   | ParameterLength of word
-  | UseDefaultValues of word
-  | AssignDefaultValues of word
-  | IndicateErrorifNullorUnset of word
-  | UseAlternativeValue of word
+  | UseDefaultValues of word * bool
+  | AssignDefaultValues of word * bool
+  | IndicateErrorifNullorUnset of word * bool
+  | UseAlternativeValue of word * bool
   | RemoveSmallestSuffixPattern of word
   | RemoveLargestSuffixPattern of word
   | RemoveSmallestPrefixPattern of word

--- a/src/CST_to_AST.ml
+++ b/src/CST_to_AST.ml
@@ -817,14 +817,14 @@ and variable_attribute__to__attribute = function
     AST.NoAttribute
   | ParameterLength word ->
     AST.ParameterLength (word__to__word word)
-  | UseDefaultValues (_, word) ->
-    AST.UseDefaultValues (word__to__word word)
-  | AssignDefaultValues (_, word) ->
-    AST.AssignDefaultValues (word__to__word word)
-  | IndicateErrorifNullorUnset (_, word) ->
-    AST.IndicateErrorifNullorUnset (word__to__word word)
-  | UseAlternativeValue (_, word) ->
-    AST.UseAlternativeValue (word__to__word word)
+  | UseDefaultValues (p, word) ->
+    AST.UseDefaultValues (word__to__word word, p.[0] = ':')
+  | AssignDefaultValues (p, word) ->
+    AST.AssignDefaultValues (word__to__word word, p.[0] = ':')
+  | IndicateErrorifNullorUnset (p, word) ->
+    AST.IndicateErrorifNullorUnset (word__to__word word, p.[0] = ':')
+  | UseAlternativeValue (p, word) ->
+    AST.UseAlternativeValue (word__to__word word, p.[0] = ':')
   | RemoveSmallestSuffixPattern word ->
     AST.RemoveSmallestSuffixPattern (word__to__word word)
   | RemoveLargestSuffixPattern word ->


### PR DESCRIPTION
True when colon is included in parameter, false otherwise. This is necessary for understanding the semantics of the expansion.

From https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_07:
"In the parameter expansions shown previously, use of the colon in the format shall result in a test for a parameter that is unset or null; omission of the colon shall result in a test for a parameter that is only unset. The following table summarizes the effect of the colon:"

Builds correctly:
```
[ishaangandhi@Ishaans-MacBook-Pro-5.local ~/Develop/morsmall]$ make
dune build @install
```