### PR TITLE
[Bugfix] Remove word value from ParameterLength attribute

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -31,7 +31,7 @@ and character_range = char list
 
 and attribute =
   | NoAttribute
-  | ParameterLength of word
+  | ParameterLength
   | UseDefaultValues of word
   | AssignDefaultValues of word
   | IndicateErrorifNullorUnset of word

--- a/src/CST_to_AST.ml
+++ b/src/CST_to_AST.ml
@@ -815,8 +815,8 @@ and word_component_double_quoted__to__word = function
 and variable_attribute__to__attribute = function
   | NoAttribute ->
     AST.NoAttribute
-  | ParameterLength word ->
-    AST.ParameterLength (word__to__word word)
+  | ParameterLength ->
+    AST.ParameterLength
   | UseDefaultValues (_, word) ->
     AST.UseDefaultValues (word__to__word word)
   | AssignDefaultValues (_, word) ->


### PR DESCRIPTION
Morbig currently incorrectly parses the # as the identifier name, then puts the actual identifier name in the ParameterLength variable_attribute type. https://github.com/colis-anr/morbig/pull/121 fixes that issue, and this pull request updates the AST to reflect those changes.

Currently, Morsmall, when used to convert from Morbig, converts `${#x}` as
```
[{ value =
   (Simple ([],
      [{ value = [(Variable ("#", (ParameterLength [])))];
         position =
         { start_p =
           { pos_fname = "parse_string_morbig"; pos_lnum = 1; pos_bol = 0;
             pos_cnum = 5 };
           end_p =
           { pos_fname = "parse_string_morbig"; pos_lnum = 1; pos_bol = 0;
             pos_cnum = 5 }
           }
         }
        ]
      ));
   position =
   { start_p =
     { pos_fname = "parse_string_morbig"; pos_lnum = 1; pos_bol = 0;
       pos_cnum = 5 };
     end_p =
     { pos_fname = "parse_string_morbig"; pos_lnum = 1; pos_bol = 0;
       pos_cnum = 5 }
     }
   }
  ]
```

Notice, the original variable `x` is gone entirely!

This is being used for the SMOOSH project with @mgree