### PR TITLE
fix dev-repo

### DIFF
--- a/morsmall.opam
+++ b/morsmall.opam
@@ -14,7 +14,7 @@ authors: [ "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>" ]
 
 homepage: "https://github.com/colis-anr/morsmall"
 bug-reports: "https://github.com/colis-anr/morsmall/issues"
-dev-repo: "git+ssh://git@github.com/colis-anr/morsmall.git"
+dev-repo: "git+https://github.com/colis-anr/morsmall.git"
 
 depends: [
   "dune"          {build}


### PR DESCRIPTION
Hi,

Otherwise, you are asked your ssh passphrase when running e.g. `opam source --dev-repo morsmall`.