### PR TITLE
Follow changes in Morbig

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -52,8 +52,8 @@ and word_component =
   | WBracketExpression of (
       Morbig.CST.bracket_expression
       [@equal (=)] [@opaque]
-      [@to_yojson Morbig.CST.bracket_expression_to_yojson]
-      [@of_yojson Morbig.CST.bracket_expression_of_yojson]
+      [@to_yojson Morbig.CSTSerializers.bracket_expression_to_yojson]
+      [@of_yojson Morbig.CSTSerializers.bracket_expression_of_yojson]
     )
     (* REVIEW: Maybe we can remove those keys? It looks like they are the
        default ones. *)

--- a/src/CST_to_AST.ml
+++ b/src/CST_to_AST.ml
@@ -815,7 +815,7 @@ and word_component_double_quoted__to__word = function
 and variable_attribute__to__attribute = function
   | NoAttribute ->
     AST.NoAttribute
-  | ParameterLength _word -> (* FIXME: what is that word supposed to be? *)
+  | ParameterLength ->
     AST.ParameterLength
   | UseDefaultValues (p, word) ->
     AST.UseDefaultValues (word__to__word word, p.[0] = ':')

--- a/src/location.ml
+++ b/src/location.ml
@@ -36,13 +36,13 @@ type 'a located = 'a Morbig.CST.located =
     position : position }
 [@@deriving eq, show {with_path=false}, yojson]
 
-class virtual ['a] located_iter      = ['a] Morbig.CST.located_iter
-class virtual ['a] located_map       = ['a] Morbig.CST.located_map
-class virtual ['a] located_reduce    = ['a] Morbig.CST.located_reduce
-class virtual ['a] located_mapreduce = ['a] Morbig.CST.located_mapreduce
-class virtual ['a] located_iter2     = ['a] Morbig.CST.located_iter2
-class virtual ['a] located_map2      = ['a] Morbig.CST.located_map2
-class virtual ['a] located_reduce2   = ['a] Morbig.CST.located_reduce2
+class virtual ['a] located_iter      = ['a] Morbig.CSTVisitors.located_iter
+class virtual ['a] located_map       = ['a] Morbig.CSTVisitors.located_map
+class virtual ['a] located_reduce    = ['a] Morbig.CSTVisitors.located_reduce
+class virtual ['a] located_mapreduce = ['a] Morbig.CSTVisitors.located_mapreduce
+class virtual ['a] located_iter2     = ['a] Morbig.CSTVisitors.located_iter2
+class virtual ['a] located_map2      = ['a] Morbig.CSTVisitors.located_map2
+class virtual ['a] located_reduce2   = ['a] Morbig.CSTVisitors.located_reduce2
 
 let dummily_located value =
   { value ; position = Morbig.CSTHelpers.dummy_position }


### PR DESCRIPTION
This PR follows a few changes in Morbig. CI is expected to fail because it hasn't been fixed yet. However, #22 fixes it and is based on `follow-changes-in-morbig` so it can serve to validate that our fix is indeed correct.