### PR TITLE
Revive tests and improve the tests runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,19 @@ jobs:
           nix develop .#${{ matrix.package }} --command true
 
       - name: Build
+        id: build
         run: |
           nix develop .#${{ matrix.package }} --command make
 
       - name: Run tests
+        if: ${{ steps.build.outcome == 'success' }}
         run: |
           nix develop .#${{ matrix.package }} --command make tests
 
       - name: Build documentation
+        ## Try building the documentation regardless of whether running the
+        ## tests failed. This gives more information out of a CI run.
+        if: ${{ steps.build.outcome == 'success' }}
         run: |
           nix develop .#${{ matrix.package }} --command make doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
         run: |
           nix develop .#${{ matrix.package }} --command make
 
+      - name: Run tests
+        run: |
+          nix develop .#${{ matrix.package }} --command make tests
+
       - name: Build documentation
         run: |
           nix develop .#${{ matrix.package }} --command make doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,21 +36,16 @@ jobs:
           nix develop .#${{ matrix.package }} --command true
 
       - name: Build
-        id: build
         run: |
           nix develop .#${{ matrix.package }} --command make
 
-      - name: Run tests
-        if: ${{ steps.build.outcome == 'success' }}
-        run: |
-          nix develop .#${{ matrix.package }} --command make tests
-
       - name: Build documentation
-        ## Try building the documentation regardless of whether running the
-        ## tests failed. This gives more information out of a CI run.
-        if: ${{ steps.build.outcome == 'success' }}
         run: |
           nix develop .#${{ matrix.package }} --command make doc
+
+      - name: Run tests
+        run: |
+          nix develop .#${{ matrix.package }} --command make tests
 
   build-with-nix:
     name: Build with Nix

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ _build
 lib
 doc
 bin
-morsmall_test_report_*.org
 /.pre-commit-config.yaml
 result
+artifacts

--- a/.nix/with-nixpkgs.nix
+++ b/.nix/with-nixpkgs.nix
@@ -27,6 +27,7 @@
             else
               inputs'.morbig.packages.with-nixpkgs)
 
+            logs
             menhirLib
             ppx_deriving
             ppx_deriving_yojson

--- a/.nix/with-nixpkgs.nix
+++ b/.nix/with-nixpkgs.nix
@@ -33,6 +33,8 @@
             visitors
             yojson
           ];
+
+          doCheck = true;
         };
     in {
       packages.with-nixpkgs = mk-with-nixpkgs { inclMorbig = false; };

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ tests:
 clean:
 	dune clean
 	rm -f bin lib doc
-	rm -f morsmall_test_report_*.org
+	rm -Rf artifacts

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ doc:
 	ln -sf _build/default/_doc doc
 
 tests:
-	dune build tests/run.exe
-	_build/default/tests/run.exe
+	dune test
 
 clean:
 	dune clean

--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
 
  (depends
   (dune                 :build)
+   logs
    menhir
    morbig
   (ocaml               (>= 4.04.0))

--- a/morsmall.opam
+++ b/morsmall.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/colis-anr/morsmall"
 bug-reports: "https://github.com/colis-anr/morsmall/issues"
 depends: [
   "dune" {build}
+  "logs"
   "menhir"
   "morbig"
   "ocaml" {>= "4.04.0"}

--- a/tests/dune
+++ b/tests/dune
@@ -4,5 +4,5 @@
 
 (executable
  (name run)
- (libraries ppx_deriving_yojson.runtime morbig morsmall unix)
+ (libraries ppx_deriving_yojson.runtime morbig morsmall unix logs)
  (flags :standard -w +A-42))

--- a/tests/dune
+++ b/tests/dune
@@ -4,5 +4,5 @@
 
 (executable
  (name run)
- (libraries ppx_deriving_yojson.runtime morbig morsmall)
+ (libraries ppx_deriving_yojson.runtime morbig morsmall unix)
  (flags :standard -w +A-42))

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,7 @@
+(rule
+ (alias runtest)
+ (action (run ./run.exe)))
+
 (executable
  (name run)
  (libraries ppx_deriving_yojson.runtime morbig morsmall)

--- a/tests/generator.ml
+++ b/tests/generator.ml
@@ -80,12 +80,12 @@ let rec g_list ~prob ~limit inhabitant =
 
 let rec g_word_component p : word_component =
   choose
-    [| 1, (fun _ -> Literal "foo") ;
-       1, (fun _ -> Variable ("x", NoAttribute)) ;
+    [| 1, (fun _ -> WLiteral "foo") ;
+       1, (fun _ -> WVariable ("x", NoAttribute)) ;
        (if p.depth <= 0 then 0 else 1),
-       (fun p -> Subshell (g_program p)) ;
-       1, (fun _ -> GlobAll) ;
-       1, (fun _ -> GlobAny) |]
+       (fun p -> WSubshell (g_program p)) ;
+       1, (fun _ -> WGlobAll) ;
+       1, (fun _ -> WGlobAny) |]
     (d p)
 
 and g_word p =
@@ -134,7 +134,7 @@ and g_command p =
   else
     choose
       [| 1, g_simple_command ;
-         1, (fun p -> Async (g_command (d p))) ;
+         1, (fun p -> Async (g_command' (d p))) ;
          1, (fun p -> Seq (g_command' (d p), g_command' (d p))) ;
          1, (fun p -> And (g_command' (d p), g_command' (d p))) ;
          1, (fun p -> Or (g_command' (d p), g_command' (d p))) ;
@@ -171,13 +171,13 @@ and g_simple_command p =
 and g_for_clause p =
   For (
       "x",
-      g_option ~prob:0.8 (fun () -> g_list ~prob:0.8 ~limit:10 (fun () -> g_word (d p))),
+      g_option ~prob:0.8 (fun () -> g_list ~prob:0.8 ~limit:10 (fun () -> g_word' (d p))),
       g_command' (d p)
     )
 
 and g_case_clause p =
   Case (
-      g_word (d p),
+      g_word' (d p),
       g_list ~prob:0.7 ~limit:5 (fun () -> g_case_item' (d p) )
     )
 
@@ -220,12 +220,12 @@ and g_redirection p =
       g_command' (d p),
       g_descr (d p),
       g_redirection_kind (d p),
-      g_word (d p)
+      g_word' (d p)
     )
 
 and g_here_document p =
   HereDocument (
       g_command' (d p),
       g_descr (d p),
-      dummily_located (g_word (d p) @ [Literal "\n"])
+      dummily_located (g_word (d p) @ [WLiteral "\n"])
     )

--- a/tests/generator.ml
+++ b/tests/generator.ml
@@ -229,3 +229,6 @@ and g_here_document p =
       g_descr (d p),
       dummily_located (g_word (d p) @ [WLiteral "\n"])
     )
+
+let g_nonempty_program p =
+  g_command' (d p) :: g_program (d p)

--- a/tests/generator.mli
+++ b/tests/generator.mli
@@ -26,3 +26,5 @@ type parameters =
 val default_parameters : parameters
 
 val g_program : parameters -> Morsmall.AST.program
+
+val g_nonempty_program : parameters -> Morsmall.AST.program

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -88,7 +88,7 @@ let run_one_test ~test_number =
   create_artifacts_directory ~test_number;
 
   Log.debug (fun m -> m "Generating AST...");
-  let input = Generator.(g_program generator_parameters) in
+  let input = Generator.(g_nonempty_program generator_parameters) in
 
   let fname = artifacts_file ~test_number "input.show" in
   Log.debug (fun m -> m "Printing it to `%s`..." fname);

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -5,7 +5,7 @@ let spf = Format.sprintf
 (******************************************************************************)
 (* Logging                                                                    *)
 
-let () = Logs.set_level ~all:true (Some Logs.Debug)
+let () = Logs.set_level ~all:true (Some Logs.Info)
 
 let level_to_string = function
   | Logs.Debug -> "DBG"

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -1,5 +1,6 @@
 let pf = Format.printf
 let fpf = Format.fprintf
+let spf = Format.sprintf
 
 exception CouldntParse of Morsmall.AST.program
 exception ASTsDontMatch of Morsmall.AST.program * Morsmall.AST.program
@@ -8,103 +9,82 @@ let generator_parameters = Generator.default_parameters
 
 let number_of_tests = 100
 
-(* *)
+let artifacts_directory_prefix =
+  "artifacts"
 
-let run_one_test () =
-  (* Create a temporary file *)
-  let (filename, out_channel) = Filename.open_temp_file "morsmall_test_" ".sh" in
-  let formatter = Format.formatter_of_out_channel out_channel in
+let create_artifacts_directory_prefix_if_not_exist () =
+  if not Sys.(file_exists artifacts_directory_prefix
+              && is_directory artifacts_directory_prefix) then
+    Unix.mkdir artifacts_directory_prefix 0o777
 
-  (* Create a random script, put it in the file *)
-  let ast = Generator.(g_program generator_parameters) in
-  Morsmall.pp_print_safe formatter ast;
+let artifacts_directory ~test_number =
+  spf "%s/%d" artifacts_directory_prefix test_number
 
-  (* Close the file *)
-  fpf formatter "@.";
-  close_out out_channel;
+let create_artifacts_directory ~test_number =
+  create_artifacts_directory_prefix_if_not_exist ();
+  Unix.mkdir (artifacts_directory ~test_number) 0o777
 
+let artifacts_file ~test_number artifact_name =
+  Filename.concat (artifacts_directory ~test_number) artifact_name
+
+let with_file fname cont =
+  let ochan = open_out fname in
+  let fmt = Format.formatter_of_out_channel ochan in
   try
-    (
-      (* Parse the file with Morbig and Morsmall *)
-      let ast' =
-        try
-          Morsmall.parse_file filename
-        with
-          Morsmall.SyntaxError _pos ->
-          raise (CouldntParse ast)
-      in
-
-      (* Compare *)
-      if not (Morsmall.AST.equal_program ast ast') then
-           raise (ASTsDontMatch (ast, ast'))
-    );
-
-    (* Clean the temporary file *)
-    Sys.remove filename
+    let res = cont fmt in
+    Format.pp_print_flush fmt ();
+    Stdlib.close_out ochan;
+    res
   with
-  | _ as exn ->
-     Sys.remove filename;
-     raise exn
+    exn ->
+    Format.pp_print_flush fmt ();
+    Stdlib.close_out ochan;
+    raise exn
+
+let run_one_test ~test_number =
+  create_artifacts_directory ~test_number;
+
+  let input = Generator.(g_program generator_parameters) in
+
+  let fname = artifacts_file ~test_number "input.show" in
+  with_file fname (fun fmt -> Morsmall.pp_print_debug fmt input);
+
+  let fname = artifacts_file ~test_number "input.sh" in
+  with_file fname (fun fmt -> Morsmall.pp_print_safe fmt input);
+
+  let output =
+    try Morsmall.parse_file fname
+    with Morsmall.SyntaxError _pos -> raise (CouldntParse input)
+  in
+
+  let fname = artifacts_file ~test_number "output.show" in
+  with_file fname (fun fmt -> Morsmall.pp_print_debug fmt output);
+
+  if not (Morsmall.AST.equal_program input output) then
+    raise (ASTsDontMatch (input, output))
 
 let () =
+  pf "@.";
   let errors = ref 0 in
-
-  for i = 1 to number_of_tests do
-    pf "Running test #%d...\r@?" i;
+  for test_number = 1 to number_of_tests do
+    pf "Running test #%d...\r@?" test_number;
     try
-      run_one_test ()
+      run_one_test ~test_number
     with
-    | _ as exn ->
-       (
-         (* Generate a report *)
-
-         let filename = "morsmall_test_report_"^(string_of_int i)^".org" in
-         let out_channel = open_out filename in
-         let formatter = Format.formatter_of_out_channel out_channel in
-         fpf formatter "#+TITLE: Morsmall Test Engine -- Report on Test #%d\n\n" i;
-         fpf formatter "* The Error\n";
-         let ast =
-           (
-             match exn with
-             | CouldntParse ast ->
-                fpf formatter "Morbig could not parse the file produced by Morsmall's printer.\n";
-                ast
-
-             | ASTsDontMatch (ast, _) ->
-                fpf formatter "The parsed AST does not coincide with the generated one.\n";
-                ast
-
-             | _ as exn -> raise exn
-           )
-         in
-         fpf formatter "* Generated AST\n%a\n" Morsmall.pp_print_debug ast;
-         fpf formatter "* Generated Shell Script\n%a\n" Morsmall.pp_print_safe ast;
-         (
-           match exn with
-           | ASTsDontMatch (_, ast') ->
-              (
-                fpf formatter
-                  "* Parsed AST\n%a\n"
-                  Morsmall.pp_print_debug ast';
-
-                try
-                  fpf formatter
-                    "* Parsed Shell Script\n%a\n"
-                    Morsmall.pp_print_safe ast'
-                with
-                  Assert_failure _ ->
-                  fpf formatter "* Error while printing the parsed AST@.";
-                  Printexc.print_backtrace out_channel
-              )
-           | _ -> ()
-         );
-         fpf formatter "@?";
-         close_out out_channel;
-
-         (* Complain *)
-         Format.eprintf "Error in test #%d: check report in '%s'\n" i filename;
-         incr errors
-       )
+      exn ->
+      (
+        incr errors;
+        pf "Error while running test #%d.@." test_number;
+        (
+          match exn with
+          | CouldntParse _input ->
+            pf "Morbig could not parse the file produced by Morsall's printer.@."
+          | ASTsDontMatch (_input, _output) ->
+            pf "The input and output ASTs do not match.@."
+          | exn -> raise exn
+        );
+        pf "@."
+      )
   done;
 
   if !errors = 0 then

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -1,3 +1,5 @@
+let pf = Format.printf
+let fpf = Format.fprintf
 
 exception CouldntParse of Morsmall.AST.program
 exception ASTsDontMatch of Morsmall.AST.program * Morsmall.AST.program
@@ -18,7 +20,7 @@ let run_one_test () =
   Morsmall.pp_print_safe formatter ast;
 
   (* Close the file *)
-  Format.fprintf formatter "@.";
+  fpf formatter "@.";
   close_out out_channel;
 
   try
@@ -48,7 +50,7 @@ let () =
   let errors = ref 0 in
 
   for i = 1 to number_of_tests do
-    Format.printf "Running test #%d...\r@?" i;
+    pf "Running test #%d...\r@?" i;
     try
       run_one_test ()
     with
@@ -59,44 +61,44 @@ let () =
          let filename = "morsmall_test_report_"^(string_of_int i)^".org" in
          let out_channel = open_out filename in
          let formatter = Format.formatter_of_out_channel out_channel in
-         Format.fprintf formatter "#+TITLE: Morsmall Test Engine -- Report on Test #%d\n\n" i;
-         Format.fprintf formatter "* The Error\n";
+         fpf formatter "#+TITLE: Morsmall Test Engine -- Report on Test #%d\n\n" i;
+         fpf formatter "* The Error\n";
          let ast =
            (
              match exn with
              | CouldntParse ast ->
-                Format.fprintf formatter "Morbig could not parse the file produced by Morsmall's printer.\n";
+                fpf formatter "Morbig could not parse the file produced by Morsmall's printer.\n";
                 ast
 
              | ASTsDontMatch (ast, _) ->
-                Format.fprintf formatter "The parsed AST does not coincide with the generated one.\n";
+                fpf formatter "The parsed AST does not coincide with the generated one.\n";
                 ast
-                
+
              | _ as exn -> raise exn
            )
          in
-         Format.fprintf formatter "* Generated AST\n%a\n" Morsmall.pp_print_debug ast;
-         Format.fprintf formatter "* Generated Shell Script\n%a\n" Morsmall.pp_print_safe ast;
+         fpf formatter "* Generated AST\n%a\n" Morsmall.pp_print_debug ast;
+         fpf formatter "* Generated Shell Script\n%a\n" Morsmall.pp_print_safe ast;
          (
            match exn with
            | ASTsDontMatch (_, ast') ->
               (
-                Format.fprintf formatter
+                fpf formatter
                   "* Parsed AST\n%a\n"
                   Morsmall.pp_print_debug ast';
 
                 try
-                  Format.fprintf formatter
+                  fpf formatter
                     "* Parsed Shell Script\n%a\n"
                     Morsmall.pp_print_safe ast'
                 with
                   Assert_failure _ ->
-                  Format.fprintf formatter "* Error while printing the parsed AST@.";
+                  fpf formatter "* Error while printing the parsed AST@.";
                   Printexc.print_backtrace out_channel
               )
            | _ -> ()
          );
-         Format.fprintf formatter "@?";
+         fpf formatter "@?";
          close_out out_channel;
 
          (* Complain *)
@@ -107,11 +109,11 @@ let () =
 
   if !errors = 0 then
     (
-      Format.printf "Successfully ran %d tests.@." number_of_tests;
+      pf "Successfully ran %d tests.@." number_of_tests;
       exit 0
     )
   else
     (
-      Format.printf "While running %d tests, got %d errors. See the reports for more details.@." number_of_tests !errors;
+      pf "While running %d tests, got %d errors. See the reports for more details.@." number_of_tests !errors;
       exit 1
     )

--- a/tests/run.ml
+++ b/tests/run.ml
@@ -94,6 +94,10 @@ let run_one_test ~test_number =
   Log.debug (fun m -> m "Printing it to `%s`..." fname);
   with_file fname (fun fmt -> Morsmall.pp_print_debug fmt input);
 
+  let fname = artifacts_file ~test_number "input.json" in
+  Log.debug (fun m -> m "Printing it to `%s`..." fname);
+  with_file fname (fun fmt -> Yojson.Safe.pretty_print fmt @@ Morsmall.AST.program_to_yojson input);
+
   let fname = artifacts_file ~test_number "input.sh" in
   Log.debug (fun m -> m "Printing it to `%s`..." fname);
   with_file fname (fun fmt -> Morsmall.pp_print_safe fmt input);
@@ -107,6 +111,10 @@ let run_one_test ~test_number =
   let fname = artifacts_file ~test_number "output.show" in
   Log.debug (fun m -> m "Printing it to `%s`..." fname);
   with_file fname (fun fmt -> Morsmall.pp_print_debug fmt output);
+
+  let fname = artifacts_file ~test_number "output.json" in
+  Log.debug (fun m -> m "Printing it to `%s`..." fname);
+  with_file fname (fun fmt -> Yojson.Safe.pretty_print fmt @@ Morsmall.AST.program_to_yojson output);
 
   if not (Morsmall.AST.equal_program input output) then
     (


### PR DESCRIPTION
This PR is here to bring back the tests that we have (and that aren't that much to begin with). There will be several parts to this:

- [x] Update the CI so that it runs tests again.
- [x] Update the Dune configuration so that `dune test` does what we expect.
- [x] Update the Nix build so that it also runs the tests.
- [x] Fix the test runner to follow changes in Morbig.

Edit: mentioned later in the PR:

- [x] ~The comparison of ASTs should be made without comparing the locations. (This is maybe already the case but it should then be documented.)~ Edit: https://github.com/colis-anr/morsmall/issues/31
- [x] ~The printing of ASTs in JSON should hide the locations in the test runner. In general, we should provide two different serialisers, one with and one without locations. Alternatively, we could rework Morsmall to provide two ASTs, one with and one without locations; this should be easy to do with a well-made functor.~ Edit: https://github.com/colis-anr/morsmall/issues/32
- [x] ~Currently, in CI, we get the logging output of the tests runner, but this does not include the artifacts. We should upload them to allow inspection.~ Edit: https://github.com/colis-anr/morsmall/issues/33