### PR TITLE
Update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1680392223,
-        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
@@ -146,12 +146,15 @@
       }
     },
     "flake-utils_4": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -245,11 +248,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1682877951,
-        "narHash": "sha256-xcrODtFyir5sHp243OEo1f+oBMpF9l5OtmB4qSiHONo=",
+        "lastModified": 1685969424,
+        "narHash": "sha256-US88j19iJmjkCeVBuRf4Zpma7qwdPnXsi6z2Q62IPPQ=",
         "owner": "colis-anr",
         "repo": "morbig",
-        "rev": "4d03370d3d0e20fbbced6985d2c71371adc3cb24",
+        "rev": "a50e6bf994aafb601ab6bc0777e9be2bc7457b2d",
         "type": "github"
       },
       "original": {
@@ -260,11 +263,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682692304,
-        "narHash": "sha256-9/lyXN2BpHw+1xE+D2ySBSLMCHWqiWu5tPHBMRDib8M=",
+        "lastModified": 1686501370,
+        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "937a9d1ee7b1351d8c55fff6611a8edf6e7c1c37",
+        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
         "type": "github"
       },
       "original": {
@@ -277,11 +280,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1680213900,
-        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
         "type": "github"
       },
       "original": {
@@ -328,16 +331,16 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -356,11 +359,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1680084639,
-        "narHash": "sha256-GDalP6niYAKvB0EsZWGhqH4ryCyzXwgodCC6FjKEnnw=",
+        "lastModified": 1682411044,
+        "narHash": "sha256-HJY+LANQ75YQSfaTCOnmtiF4pF8d9Eb4dz+wLyNAihE=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "a98614af305ce44076cf244ea3a0b098f2be2254",
+        "rev": "02f7ae28a210e17ca5811b0a4c116acd94e82faa",
         "type": "github"
       },
       "original": {
@@ -382,11 +385,11 @@
         "opam2json": "opam2json_2"
       },
       "locked": {
-        "lastModified": 1682411044,
-        "narHash": "sha256-HJY+LANQ75YQSfaTCOnmtiF4pF8d9Eb4dz+wLyNAihE=",
+        "lastModified": 1686646524,
+        "narHash": "sha256-wBjcldsPldqrqOffx38H1fwQNLpRY6jciD30LwpIYZc=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "02f7ae28a210e17ca5811b0a4c116acd94e82faa",
+        "rev": "87b149ee24c5fe8b66b51582353dff90f822697d",
         "type": "github"
       },
       "original": {
@@ -430,11 +433,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1673100816,
-        "narHash": "sha256-v5E5ZymUpTE3ytxjs6vfiNsFCPGbWJviAnrk6q7SfbM=",
+        "lastModified": 1682021363,
+        "narHash": "sha256-nDUDFwyOTZDALeqqEDnF2PTPIHT4sVYdQXUbRt03oNs=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "9f576a1b9dd69b86bde542d9f89d534c0cc916b8",
+        "rev": "786c55fa77c37f07eceea7d6a9bec04d2225e302",
         "type": "github"
       },
       "original": {
@@ -538,11 +541,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1682596858,
-        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "lastModified": 1686213770,
+        "narHash": "sha256-Re6xXLEqQ/HRnThryumyGzEf3Uv0Pl4cuG50MrDofP8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "rev": "182af51202998af5b64ddecaa7ff9be06425399b",
         "type": "github"
       },
       "original": {
@@ -558,6 +561,21 @@
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix_2",
         "pre-commit-hooks": "pre-commit-hooks_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,8 @@
         packages.default = self'.packages.with-nixpkgs;
 
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs.ocamlPackages; [
-            headache
-            ocaml-lsp
-            ocp-indent
-          ];
+          buildInputs = (with pkgs; [ headache ])
+            ++ (with pkgs.ocamlPackages; [ ocaml-lsp ocp-indent ]);
           inputsFrom = [ self'.packages.default ];
           shellHook = config.pre-commit.installationScript;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,9 @@
 
     morbig.url = "github:colis-anr/morbig";
     morbig.inputs.nixpkgs.follows = "nixpkgs";
+    morbig.inputs.opam-nix.follows = "";
+    ## NOTE: We do not use Morbig's `opam-nix`-based part of the flake here, so
+    ## we can remove that input to save space and time.
 
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";

--- a/morsmall.opam
+++ b/morsmall.opam
@@ -37,5 +37,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/colis-anr/morsmall.git"
 pin-depends: [
-  [ "morbig.dev" "git+https://github.com/colis-anr/morbig#4d03370d3d0e20fbbced6985d2c71371adc3cb24" ]
+  [ "morbig.dev" "git+https://github.com/colis-anr/morbig#a50e6bf994aafb601ab6bc0777e9be2bc7457b2d" ]
 ]

--- a/morsmall.opam.template
+++ b/morsmall.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  [ "morbig.dev" "git+https://github.com/colis-anr/morbig#4d03370d3d0e20fbbced6985d2c71371adc3cb24" ]
+  [ "morbig.dev" "git+https://github.com/colis-anr/morbig#a50e6bf994aafb601ab6bc0777e9be2bc7457b2d" ]
 ]


### PR DESCRIPTION
- Update Morbig in flake and pin-depends.
- Update other flake dependencies (in particular `nixpkgs` and `pre-commit-hooks`).
- Ignore Morbig's `opam-nix` flake input to save space and time.