### PR TITLE
Rework redirections, authorising them to be standalone

### DIFF
--- a/src/AST.ml
+++ b/src/AST.ml
@@ -81,8 +81,8 @@ and command =
   | While of command' * command'
   | Until of command' * command'
   | Function of name * command'
-  | Redirection of command' * descr * kind * word'
-  | HereDocument of command' * descr * word'
+  | Redirection of command' option * descr * kind * word'
+  | HereDocument of command' option * descr * word'
 
 and command' = command located
 
@@ -181,9 +181,11 @@ let if_ ~then_ ?else_ test = If (test, then_, else_)
 let while_ test body = While (test, body)
 let until test body = Until (test, body)
 let function_ name body = Function (name, body)
-let redirection command descr kind target = Redirection (command, descr, kind, target)
 
-let hereDocument command descr content =
+let redirection ?around descr kind target =
+  Redirection (around, descr, kind, target)
+
+let hereDocument ?around descr content =
   List.iter
     (
       function
@@ -195,7 +197,7 @@ let hereDocument command descr content =
       | _ -> ()
     )
     content.Location.value;
-  HereDocument (command, descr, content)
+  HereDocument (around, descr, content)
 
 (* let simple' ?(loc=Location.dummy) ?assignments words = *)
 

--- a/src/AST.mli
+++ b/src/AST.mli
@@ -217,8 +217,8 @@ and command = private
   | Function of name * command'
 
   (* Redirection *)
-  | Redirection of command' * descr * kind * word'
-  | HereDocument of command' * descr * word'
+  | Redirection of command' option * descr * kind * word'
+  | HereDocument of command' option * descr * word'
 
 and command' = command located
 
@@ -277,12 +277,12 @@ val if_ : then_:command' -> ?else_:command' -> command' -> command
 val while_ : command' -> command' -> command
 val until : command' -> command' -> command
 val function_ : name -> command' -> command
-val redirection : command' -> descr -> kind -> word' -> command
+val redirection : ?around:command' -> descr -> kind -> word' -> command
 
 (** [hereDocument c d w] creates a here-document redirection around [c], about
     descriptor [d] and containing the word [w]. The last newline must not be
     included. *)
-val hereDocument : command' -> descr -> word' -> command
+val hereDocument : ?around:command' -> descr -> word' -> command
 
 (** {3 Others} *)
 

--- a/src/CST_to_AST.ml
+++ b/src/CST_to_AST.ml
@@ -627,14 +627,14 @@ and io_redirect__to__command (io_redirect : io_redirect) (command' : AST.command
   | IoRedirect_IoFile io_file' ->
      let kind, word' = io_file'__to__kind_word' io_file' in
      AST.redirection
-         command'
+         ~around:command'
          (ASTUtils.default_redirection_descriptor kind)
          kind
          word'
   | IoRedirect_IoNumber_IoFile (io_number, io_file') ->
      let kind, word' = io_file'__to__kind_word' io_file' in
      AST.redirection
-         command'
+         ~around:command'
          (io_number__to__int io_number)
          kind
          word'
@@ -642,14 +642,14 @@ and io_redirect__to__command (io_redirect : io_redirect) (command' : AST.command
      let _strip, word' = io_here'__to__strip_word' io_here' in
      (* FIXME: strip that word if needed *)
      AST.hereDocument
-         command'
+         ~around:command'
          0
          (Location.map_located assert_remove_last_newline_from_word word')
   | IoRedirect_IoNumber_IoHere (io_number, io_here') ->
      let _strip, word' = io_here'__to__strip_word' io_here' in
      (* FIXME: strip that word if needed *)
      AST.hereDocument
-         command'
+         ~around:command'
          (io_number__to__int io_number)
          (Location.map_located assert_remove_last_newline_from_word word')
 

--- a/src/printer/safe.ml
+++ b/src/printer/safe.ml
@@ -252,7 +252,7 @@ and pp_command ppf (command : command) =
          pp_assignments' assignments
          pp_words' words
 
-    | Redirection (command, descr, kind, file) ->
+    | Redirection (Some command, descr, kind, file) ->
        (* The space is required because "the [descriptor] must be delimited from any preceding text". *)
        fpf ppf "%a %d%a%a"
          pp_command' command
@@ -260,10 +260,24 @@ and pp_command ppf (command : command) =
          pp_redirection_kind kind
          pp_word' file
 
-    | HereDocument (command, descr, content) ->
+    | Redirection (None, descr, kind, file) ->
+       fpf ppf "%d%a%a"
+         descr
+         pp_redirection_kind kind
+         pp_word' file
+
+    | HereDocument (Some command, descr, content) ->
        let eof = "EOF" in (* FIXME: check that no line contains `EOF`, or get it from the grammar? *)
        fpf ppf "%a %d<<%s\n%a\n%s\n"
          pp_command' command
+         descr
+         eof
+         pp_word' content
+         eof
+
+    | HereDocument (None, descr, content) ->
+       let eof = "EOF" in (* FIXME: check that no line contains `EOF`, or get it from the grammar? *)
+       fpf ppf "%d<<%s\n%a\n%s\n"
          descr
          eof
          pp_word' content

--- a/tests/qcheck/generator.ml
+++ b/tests/qcheck/generator.ml
@@ -184,9 +184,9 @@ and gen_command : command Gen.sized = fun s ->
           while_ <$> gen_command' s <*> gen_command' s ;
           until <$> gen_command' s <*> gen_command' s ;
           function_ <$> gen_name <*> gen_command' s ;
-          redirection <$> gen_command' s <*> gen_descr <*> gen_kind <*> gen_word' s ;
-          Gen.map3_retry hereDocument (gen_command' s) gen_descr (gen_word' s)
-            ~fallback:(hereDocument <$> gen_command' s <*> gen_descr <*> Gen.pure (Location.locate [])) ;
+          (fun around -> redirection ~around) <$> gen_command' s <*> gen_descr <*> gen_kind <*> gen_word' s ;
+          Gen.map3_retry (fun around -> hereDocument ~around) (gen_command' s) gen_descr (gen_word' s)
+            ~fallback:((fun around -> hereDocument ~around) <$> gen_command' s <*> gen_descr <*> Gen.pure (Location.locate [])) ;
         ]
     )
 


### PR DESCRIPTION
Brings down the `golden` suite to 33 failures.